### PR TITLE
Use better context sharing

### DIFF
--- a/src/context/profile.svelte.ts
+++ b/src/context/profile.svelte.ts
@@ -1,0 +1,31 @@
+import type { ValidStats } from "$types/stats";
+import { getContext, setContext } from "svelte";
+
+class ProfileContext {
+  #data = $state<ValidStats>()!;
+
+  get profile() {
+    return this.#data;
+  }
+
+  set profile(value: ValidStats) {
+    this.#data = value;
+  }
+
+  constructor(profile: ValidStats) {
+    this.#data = profile;
+  }
+}
+
+export function setProfileCtx(profile: ValidStats) {
+  const existing = getProfileCtx();
+  if (existing) {
+    existing.profile = profile;
+    return;
+  }
+  setContext("profile", new ProfileContext(profile));
+}
+
+export function getProfileCtx() {
+  return getContext("profile") as ProfileContext;
+}

--- a/src/context/profile.svelte.ts
+++ b/src/context/profile.svelte.ts
@@ -12,6 +12,10 @@ class ProfileContext {
     this.#data = value;
   }
 
+  get misc() {
+    return this.#data.misc;
+  }
+
   constructor(profile: ValidStats) {
     this.#data = profile;
   }

--- a/src/lib/components/Skin3D.svelte
+++ b/src/lib/components/Skin3D.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { Stats as StatsType } from "$lib/types/stats";
   import * as skinview3d from "skinview3d";
-  import { getContext, onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   let { class: className }: { class: string | undefined } = $props();
   let viewer: skinview3d.SkinViewer;

--- a/src/lib/components/Skin3DView.svelte
+++ b/src/lib/components/Skin3DView.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { Stats as StatsType } from "$lib/types/stats";
   import * as skinview3d from "skinview3d";
-  import { getContext, onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   let { class: className }: { class: string | undefined } = $props();
   let viewer: skinview3d.SkinViewer;

--- a/src/lib/layouts/stats/AdditionalStats.svelte
+++ b/src/lib/layouts/stats/AdditionalStats.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import { formatNumber } from "$lib/shared/helper";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format as dateFormat, formatDistanceToNowStrict } from "date-fns";
   import { format as numberFormat } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   const defaultPatternDecimal: string = "0,0.##";
   const defaultPattern: string = "0,0";

--- a/src/lib/layouts/stats/Main.svelte
+++ b/src/lib/layouts/stats/Main.svelte
@@ -10,7 +10,7 @@
 
   let { profile }: { profile: StatsType } = $props();
 
-  $effect(() => {
+  $effect.pre(() => {
     setProfileCtx(profile as ValidStats);
   });
 </script>

--- a/src/lib/layouts/stats/Main.svelte
+++ b/src/lib/layouts/stats/Main.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
+  import { setProfileCtx } from "$ctx/profile.svelte";
   import Navbar from "$lib/components/Navbar.svelte";
   import AdditionalStats from "$lib/layouts/stats/AdditionalStats.svelte";
   import PlayerProfile from "$lib/layouts/stats/PlayerProfile.svelte";
   import Skills from "$lib/layouts/stats/Skills.svelte";
   import Stats from "$lib/layouts/stats/Stats.svelte";
   import Armor from "$lib/sections/stats/Armor.svelte";
-  import type { Stats as StatsType } from "$lib/types/stats";
-  import { setContext } from "svelte";
+  import type { Stats as StatsType, ValidStats } from "$lib/types/stats";
 
   let { profile }: { profile: StatsType } = $props();
 
-  setContext<StatsType>("profile", profile);
+  $effect(() => {
+    setProfileCtx(profile as ValidStats);
+  });
 </script>
 
 <div class="relative @container/parent">

--- a/src/lib/layouts/stats/PlayerProfile.svelte
+++ b/src/lib/layouts/stats/PlayerProfile.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import { flyAndScale } from "$lib/shared/utils";
   import { favorites } from "$lib/stores/favorites";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Avatar, Button, DropdownMenu, Tooltip } from "bits-ui";
   import ChevronLeft from "lucide-svelte/icons/chevron-left";
   import ChevronRight from "lucide-svelte/icons/chevron-right";
   import ExternalLink from "lucide-svelte/icons/external-link";
   import Share from "lucide-svelte/icons/share";
   import Star from "lucide-svelte/icons/star";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
+
   const iconMapper: Record<string, string> = {
     TWITTER: "x-twitter.svg",
     YOUTUBE: "youtube.svg",
@@ -45,7 +45,7 @@
     </DropdownMenu.Trigger>
 
     <DropdownMenu.Content class="z-[99999]  min-w-64 overflow-hidden rounded-lg bg-background-grey/95 text-3xl font-semibold" align="start" side="bottom" transition={flyAndScale} transitionConfig={{ y: -8, duration: 150 }}>
-      {#each profile.profiles as otherProfile}
+      {#each profile.profiles ?? [] as otherProfile}
         <DropdownMenu.Item href={`/stats/${profile.username}/${otherProfile.cute_name}`} class="flex items-center p-4 hover:bg-text/20" data-sveltekit-preload-code="viewport">
           {otherProfile.cute_name}
           {#if otherProfile.game_mode === "bingo"}

--- a/src/lib/layouts/stats/Skills.svelte
+++ b/src/lib/layouts/stats/Skills.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import Skillbar from "$lib/components/Skillbar.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 </script>
 
 <div class="skills space-y-2 pr-2 @md:pr-0">

--- a/src/lib/layouts/stats/Stats.svelte
+++ b/src/lib/layouts/stats/Stats.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import Stat from "$lib/components/Stat.svelte";
   import { getPlayerStats } from "$lib/shared/player_stats";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Collapsible } from "bits-ui";
   import { quadInOut } from "svelte/easing";
-
-  import { getContext } from "svelte";
   import { slide } from "svelte/transition";
 
-  const profile = getContext<StatsType>("profile");
-
-  const stats = getPlayerStats(profile);
+  const { profile } = getProfileCtx();
+  const stats = $derived(getPlayerStats(profile));
 </script>
 
 <div class="stats flex flex-col">

--- a/src/lib/sections/stats/Accessories.svelte
+++ b/src/lib/sections/stats/Accessories.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Bonus from "$lib/components/Bonus.svelte";
   import Item from "$lib/components/Item.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { RARITY_COLORS } from "$lib/shared/constants/items";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Collapsible } from "bits-ui";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
   const accessories = profile.accessories;
 </script>
 

--- a/src/lib/sections/stats/Accessories.svelte
+++ b/src/lib/sections/stats/Accessories.svelte
@@ -10,7 +10,7 @@
   import ChevronDown from "lucide-svelte/icons/chevron-down";
 
   const { profile } = getProfileCtx();
-  const accessories = profile.accessories;
+  const accessories = $derived(profile.accessories);
 </script>
 
 <Items title="Accessories">

--- a/src/lib/sections/stats/Armor.svelte
+++ b/src/lib/sections/stats/Armor.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import Bonus from "$lib/components/Bonus.svelte";
   import Item from "$lib/components/Item.svelte";
   import Wardrobe from "$lib/components/Wardrobe.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { getRarityClass } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   const armor = profile.items.armor;
   const equipment = profile.items.equipment;

--- a/src/lib/sections/stats/Armor.svelte
+++ b/src/lib/sections/stats/Armor.svelte
@@ -9,10 +9,10 @@
 
   const { profile } = getProfileCtx();
 
-  const armor = profile.items.armor;
-  const equipment = profile.items.equipment;
-  const wardrobe = profile.items.wardrobe;
-  const firstWardrobeItems = wardrobe.map((wardrobeItems) => wardrobeItems.find((piece) => piece));
+  const armor = $derived(profile.items.armor);
+  const equipment = $derived(profile.items.equipment);
+  const wardrobe = $derived(profile.items.wardrobe);
+  const firstWardrobeItems = $derived(wardrobe.map((wardrobeItems) => wardrobeItems.find((piece) => piece)));
 </script>
 
 <Items title="Armor">

--- a/src/lib/sections/stats/Bestiary.svelte
+++ b/src/lib/sections/stats/Bestiary.svelte
@@ -8,7 +8,7 @@
 
   const { profile } = getProfileCtx();
 
-  const bestiary = profile.bestiary;
+  const bestiary = $derived(profile.bestiary);
 </script>
 
 <Items title="Bestiary" class="flex-col">

--- a/src/lib/sections/stats/Bestiary.svelte
+++ b/src/lib/sections/stats/Bestiary.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   const bestiary = profile.bestiary;
 </script>

--- a/src/lib/sections/stats/Collections.svelte
+++ b/src/lib/sections/stats/Collections.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { cn } from "$lib/shared/utils";
-
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
-  const collections = profile.collections;
+  const collections = $derived(profile.collections);
 </script>
 
 <Items title="Collections" class="flex-col">

--- a/src/lib/sections/stats/CrimsonIsle.svelte
+++ b/src/lib/sections/stats/CrimsonIsle.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { formatTime } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
-  const isle = profile.crimson_isle;
+  const isle = $derived(profile.crimson_isle);
 </script>
 
 <Items title="Crimson Isle" class="flex-col">

--- a/src/lib/sections/stats/Dungeons.svelte
+++ b/src/lib/sections/stats/Dungeons.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
   import Skillbar from "$lib/components/Skillbar.svelte";
   import { formatNumber } from "$lib/shared/helper";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Avatar, Collapsible } from "bits-ui";
   import { formatDate, formatDistanceToNowStrict } from "date-fns";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
   import Image from "lucide-svelte/icons/image";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
-  const dungeons = profile.dungeons;
+  const { profile } = getProfileCtx();
+  const dungeons = $derived(profile.dungeons);
 </script>
 
 <div class="space-y-4">

--- a/src/lib/sections/stats/Inventory.svelte
+++ b/src/lib/sections/stats/Inventory.svelte
@@ -1,84 +1,86 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import Item from "$lib/components/Item.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
-  import type { ProcessedSkyBlockItem, ValidStats as StatsType } from "$lib/types/stats";
+  import type { ProcessedSkyBlockItem } from "$lib/types/stats";
   import { Avatar, ScrollArea, Tabs } from "bits-ui";
   import Image from "lucide-svelte/icons/image";
-  import { getContext } from "svelte";
   import { cubicInOut } from "svelte/easing";
   import { writable } from "svelte/store";
   import { crossfade, fade } from "svelte/transition";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
-  const inventory = profile.items.inventory.slice(9).concat(profile.items.inventory.slice(0, 9));
-  const backpack = profile.items.backpack;
-  const enderchest = profile.items.enderchest;
-  const vault = profile.items.personal_vault;
-  const accs = profile.items.talisman_bag;
-  const pots = profile.items.potion_bag;
-  const fish = profile.items.fishing_bag;
-  const quiver = profile.items.quiver;
-  const museum = profile.items.museum;
+  const inventory = $derived(profile.items.inventory.slice(9).concat(profile.items.inventory.slice(0, 9)));
+  const backpack = $derived(profile.items.backpack);
+  const enderchest = $derived(profile.items.enderchest);
+  const vault = $derived(profile.items.personal_vault);
+  const accs = $derived(profile.items.talisman_bag);
+  const pots = $derived(profile.items.potion_bag);
+  const fish = $derived(profile.items.fishing_bag);
+  const quiver = $derived(profile.items.quiver);
+  const museum = $derived(profile.items.museum);
 
   const openTab = writable<string>("inv");
 
-  const tabs = [
-    {
-      id: "inv",
-      icon: `https://crafatar.com/renders/head/${profile.uuid}?overlay`,
-      items: inventory,
-      hr: 27
-    },
-    {
-      id: "storage",
-      icon: "/api/item/chest",
-      items: backpack,
-      hr: 45
-    },
-    {
-      id: "ender",
-      icon: "/api/item/ender_chest",
-      items: enderchest,
-      hr: 45
-    },
-    {
-      id: "vault",
-      icon: "/api/head/f7aadff9ddc546fdcec6ed5919cc39dfa8d0c07ff4bc613a19f2e6d7f2593",
-      items: vault,
-      hr: 45
-    },
-    {
-      id: "accs",
-      icon: "/api/head/961a918c0c49ba8d053e522cb91abc74689367b4d8aa06bfc1ba9154730985ff",
-      items: accs,
-      hr: 45
-    },
-    {
-      id: "pots",
-      icon: "/api/head/9f8b82427b260d0a61e6483fc3b2c35a585851e08a9a9df372548b4168cc817c",
-      items: pots,
-      hr: 45
-    },
-    {
-      id: "fish",
-      icon: "/api/head/eb8e297df6b8dffcf135dba84ec792d420ad8ecb458d144288572a84603b1631",
-      items: fish,
-      hr: 45
-    },
-    {
-      id: "quiver",
-      icon: "/api/head/4cb3acdc11ca747bf710e59f4c8e9b3d949fdd364c6869831ca878f0763d1787",
-      items: quiver,
-      hr: 45
-    },
-    {
-      id: "museum",
-      icon: "/api/head/438cf3f8e54afc3b3f91d20a49f324dca1486007fe545399055524c17941f4dc",
-      items: museum,
-      hr: 54
-    }
-  ].filter((tab) => tab.items.length > 0);
+  const tabs = $derived(
+    [
+      {
+        id: "inv",
+        icon: `https://crafatar.com/renders/head/${profile.uuid}?overlay`,
+        items: inventory,
+        hr: 27
+      },
+      {
+        id: "storage",
+        icon: "/api/item/chest",
+        items: backpack,
+        hr: 45
+      },
+      {
+        id: "ender",
+        icon: "/api/item/ender_chest",
+        items: enderchest,
+        hr: 45
+      },
+      {
+        id: "vault",
+        icon: "/api/head/f7aadff9ddc546fdcec6ed5919cc39dfa8d0c07ff4bc613a19f2e6d7f2593",
+        items: vault,
+        hr: 45
+      },
+      {
+        id: "accs",
+        icon: "/api/head/961a918c0c49ba8d053e522cb91abc74689367b4d8aa06bfc1ba9154730985ff",
+        items: accs,
+        hr: 45
+      },
+      {
+        id: "pots",
+        icon: "/api/head/9f8b82427b260d0a61e6483fc3b2c35a585851e08a9a9df372548b4168cc817c",
+        items: pots,
+        hr: 45
+      },
+      {
+        id: "fish",
+        icon: "/api/head/eb8e297df6b8dffcf135dba84ec792d420ad8ecb458d144288572a84603b1631",
+        items: fish,
+        hr: 45
+      },
+      {
+        id: "quiver",
+        icon: "/api/head/4cb3acdc11ca747bf710e59f4c8e9b3d949fdd364c6869831ca878f0763d1787",
+        items: quiver,
+        hr: 45
+      },
+      {
+        id: "museum",
+        icon: "/api/head/438cf3f8e54afc3b3f91d20a49f324dca1486007fe545399055524c17941f4dc",
+        items: museum,
+        hr: 54
+      }
+    ].filter((tab) => tab.items.length > 0)
+  );
 
   const openStorageTab = writable<string>("0");
 

--- a/src/lib/sections/stats/Minions.svelte
+++ b/src/lib/sections/stats/Minions.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Avatar, Button } from "bits-ui";
   import ExternalLink from "lucide-svelte/icons/external-link";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   const minions = profile.minions;
 

--- a/src/lib/sections/stats/Minions.svelte
+++ b/src/lib/sections/stats/Minions.svelte
@@ -9,7 +9,7 @@
 
   const { profile } = getProfileCtx();
 
-  const minions = profile.minions;
+  const minions = $derived(profile.minions);
 
   const romanTiers = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII"];
   const arabicTiers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];

--- a/src/lib/sections/stats/MiscSection.svelte
+++ b/src/lib/sections/stats/MiscSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
-  import type { Stats as StatsType } from "$lib/types/stats";
-  import { getContext, setContext } from "svelte";
+  import { setContext } from "svelte";
   import Auctions from "./misc/auctions.svelte";
   import Claimed from "./misc/claimed.svelte";
   import Damage from "./misc/damage.svelte";
@@ -18,7 +18,7 @@
   import Uncategorized from "./misc/uncategorized.svelte";
   import Upgrades from "./misc/upgrades.svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   setContext("misc", profile.misc);
 </script>

--- a/src/lib/sections/stats/MiscSection.svelte
+++ b/src/lib/sections/stats/MiscSection.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-  import { getProfileCtx } from "$ctx/profile.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
-  import { setContext } from "svelte";
   import Auctions from "./misc/auctions.svelte";
   import Claimed from "./misc/claimed.svelte";
   import Damage from "./misc/damage.svelte";
@@ -17,10 +15,6 @@
   import Races from "./misc/races.svelte";
   import Uncategorized from "./misc/uncategorized.svelte";
   import Upgrades from "./misc/upgrades.svelte";
-
-  const { profile } = getProfileCtx();
-
-  setContext("misc", profile.misc);
 </script>
 
 <SectionTitle class="mb-4">Miscellaneous</SectionTitle>

--- a/src/lib/sections/stats/Pets.svelte
+++ b/src/lib/sections/stats/Pets.svelte
@@ -17,14 +17,13 @@
   {/each}
   */
 
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import { formatNumber, getRarityClass, uniqBy } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Collapsible } from "bits-ui";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
   const pets = profile.pets;
   const activePet = pets.pets.find((pet) => pet.active === true);
   const uniquePets = uniqBy(pets.pets, "type");

--- a/src/lib/sections/stats/Pets.svelte
+++ b/src/lib/sections/stats/Pets.svelte
@@ -24,10 +24,10 @@
   import ChevronDown from "lucide-svelte/icons/chevron-down";
 
   const { profile } = getProfileCtx();
-  const pets = profile.pets;
-  const activePet = pets.pets.find((pet) => pet.active === true);
-  const uniquePets = uniqBy(pets.pets, "type");
-  const otherPets = pets.pets.filter((pet) => !uniquePets.includes(pet));
+  const pets = $derived(profile.pets);
+  const activePet = $derived(pets.pets.find((pet) => pet.active === true));
+  const uniquePets = $derived(uniqBy(pets.pets, "type"));
+  const otherPets = $derived(pets.pets.filter((pet) => !uniquePets.includes(pet)));
 
   // TODO: Once helper functions get moved to a global location, we can remove this function
 </script>

--- a/src/lib/sections/stats/Rift.svelte
+++ b/src/lib/sections/stats/Rift.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { formatDate, formatDistanceToNowStrict } from "date-fns";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 
   const rift = profile.rift;
 </script>

--- a/src/lib/sections/stats/Rift.svelte
+++ b/src/lib/sections/stats/Rift.svelte
@@ -10,7 +10,7 @@
 
   const { profile } = getProfileCtx();
 
-  const rift = profile.rift;
+  const rift = $derived(profile.rift);
 </script>
 
 <Items title="Rift" class="flex-col">

--- a/src/lib/sections/stats/SkillsSection.svelte
+++ b/src/lib/sections/stats/SkillsSection.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
-  import type { Stats as StatsType } from "$lib/types/stats";
-  import { getContext } from "svelte";
   import Enchanting from "./skills/enchanting.svelte";
   import Farming from "./skills/farming.svelte";
   import Fishing from "./skills/fishing.svelte";
   import Mining from "./skills/mining.svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 </script>
 
 <SectionTitle class="pt-4">Skills</SectionTitle>

--- a/src/lib/sections/stats/Slayer.svelte
+++ b/src/lib/sections/stats/Slayer.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Bonus from "$lib/components/Bonus.svelte";
   import SectionTitle from "$lib/components/SectionTitle.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Avatar, Progress } from "bits-ui";
   import Image from "lucide-svelte/icons/image";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
   const slayer = profile.slayer;
 </script>
 

--- a/src/lib/sections/stats/Slayer.svelte
+++ b/src/lib/sections/stats/Slayer.svelte
@@ -8,7 +8,7 @@
   import { format } from "numerable";
 
   const { profile } = getProfileCtx();
-  const slayer = profile.slayer;
+  const slayer = $derived(profile.slayer);
 </script>
 
 <div class="space-y-4">

--- a/src/lib/sections/stats/Weapons.svelte
+++ b/src/lib/sections/stats/Weapons.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Item from "$lib/components/Item.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  const { profile } = getProfileCtx();
 </script>
 
 <Items title="Weapons">

--- a/src/lib/sections/stats/misc/auctions.svelte
+++ b/src/lib/sections/stats/misc/auctions.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.auctions != null}

--- a/src/lib/sections/stats/misc/claimed.svelte
+++ b/src/lib/sections/stats/misc/claimed.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { formatDate, formatDistanceToNowStrict } from "date-fns";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.claimed_items != null}

--- a/src/lib/sections/stats/misc/damage.svelte
+++ b/src/lib/sections/stats/misc/damage.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.damage != null}

--- a/src/lib/sections/stats/misc/dragons.svelte
+++ b/src/lib/sections/stats/misc/dragons.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.dragons != null}

--- a/src/lib/sections/stats/misc/endstone.svelte
+++ b/src/lib/sections/stats/misc/endstone.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.endstone_protector != null}

--- a/src/lib/sections/stats/misc/essence.svelte
+++ b/src/lib/sections/stats/misc/essence.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.essence != null}

--- a/src/lib/sections/stats/misc/gifts.svelte
+++ b/src/lib/sections/stats/misc/gifts.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.gifts != null}

--- a/src/lib/sections/stats/misc/jerry.svelte
+++ b/src/lib/sections/stats/misc/jerry.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.season_of_jerry != null}

--- a/src/lib/sections/stats/misc/kills.svelte
+++ b/src/lib/sections/stats/misc/kills.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
   import VirtualList from "svelte-tiny-virtual-list";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.kills != null}

--- a/src/lib/sections/stats/misc/mythological.svelte
+++ b/src/lib/sections/stats/misc/mythological.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.mythological_event != null}

--- a/src/lib/sections/stats/misc/pet.svelte
+++ b/src/lib/sections/stats/misc/pet.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.pet_milestones != null}

--- a/src/lib/sections/stats/misc/potions.svelte
+++ b/src/lib/sections/stats/misc/potions.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.effects != null}

--- a/src/lib/sections/stats/misc/races.svelte
+++ b/src/lib/sections/stats/misc/races.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.races != null}

--- a/src/lib/sections/stats/misc/uncategorized.svelte
+++ b/src/lib/sections/stats/misc/uncategorized.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.uncategorized != null}

--- a/src/lib/sections/stats/misc/upgrades.svelte
+++ b/src/lib/sections/stats/misc/upgrades.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { format } from "numerable";
-  import { getContext } from "svelte";
 
-  const misc = getContext<StatsType["misc"]>("misc");
+  const { misc } = getProfileCtx();
 </script>
 
 {#if misc.profile_upgrades != null}

--- a/src/lib/sections/stats/skills/enchanting.svelte
+++ b/src/lib/sections/stats/skills/enchanting.svelte
@@ -2,14 +2,13 @@
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Collapsible } from "bits-ui";
   import { formatDistanceStrict } from "date-fns";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
-  import { getContext } from "svelte";
   import { fade } from "svelte/transition";
 
-  const profile = getContext<StatsType>("profile");
+  import { getProfileCtx } from "$ctx/profile.svelte";
+  const { profile } = getProfileCtx();
 </script>
 
 <SectionSubtitle>Enchanting</SectionSubtitle>

--- a/src/lib/sections/stats/skills/enchanting.svelte
+++ b/src/lib/sections/stats/skills/enchanting.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
@@ -7,7 +8,6 @@
   import ChevronDown from "lucide-svelte/icons/chevron-down";
   import { fade } from "svelte/transition";
 
-  import { getProfileCtx } from "$ctx/profile.svelte";
   const { profile } = getProfileCtx();
 </script>
 

--- a/src/lib/sections/stats/skills/farming.svelte
+++ b/src/lib/sections/stats/skills/farming.svelte
@@ -6,12 +6,11 @@
   import Items from "$lib/layouts/stats/Items.svelte";
   import { formatNumber, getRarityClass } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Collapsible } from "bits-ui";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
-  import { getContext } from "svelte";
 
-  const profile = getContext<StatsType>("profile");
+  import { getProfileCtx } from "$ctx/profile.svelte";
+  const { profile } = getProfileCtx();
 
   const highestPriorityFarmingTool = profile.items.farming_tools.highest_priority_tool;
   const farmingTools = profile.items.farming_tools.tools;

--- a/src/lib/sections/stats/skills/farming.svelte
+++ b/src/lib/sections/stats/skills/farming.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import Item from "$lib/components/Item.svelte";
@@ -9,11 +10,10 @@
   import { Collapsible } from "bits-ui";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
 
-  import { getProfileCtx } from "$ctx/profile.svelte";
   const { profile } = getProfileCtx();
 
-  const highestPriorityFarmingTool = profile.items.farming_tools.highest_priority_tool;
-  const farmingTools = profile.items.farming_tools.tools;
+  const highestPriorityFarmingTool = $derived(profile.items.farming_tools.highest_priority_tool);
+  const farmingTools = $derived(profile.items.farming_tools.tools);
 </script>
 
 <SectionSubtitle>Farming</SectionSubtitle>

--- a/src/lib/sections/stats/skills/fishing.svelte
+++ b/src/lib/sections/stats/skills/fishing.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Chip from "$lib/components/Chip.svelte";
   import Item from "$lib/components/Item.svelte";
@@ -12,11 +13,10 @@
   import { format } from "numerable";
   import { fade } from "svelte/transition";
 
-  import { getProfileCtx } from "$ctx/profile.svelte";
   const { profile } = getProfileCtx();
 
-  const highestPriorityFishingTool = profile.items.fishing_tools.highest_priority_tool;
-  const fishingTools = profile.items.fishing_tools.tools;
+  const highestPriorityFishingTool = $derived(profile.items.fishing_tools.highest_priority_tool);
+  const fishingTools = $derived(profile.items.fishing_tools.tools);
 </script>
 
 <SectionSubtitle>Fishing</SectionSubtitle>

--- a/src/lib/sections/stats/skills/fishing.svelte
+++ b/src/lib/sections/stats/skills/fishing.svelte
@@ -6,15 +6,14 @@
   import Items from "$lib/layouts/stats/Items.svelte";
   import { getRarityClass, renderLore } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { Avatar, Collapsible } from "bits-ui";
   import ChevronDown from "lucide-svelte/icons/chevron-down";
   import Image from "lucide-svelte/icons/image";
   import { format } from "numerable";
-  import { getContext } from "svelte";
   import { fade } from "svelte/transition";
 
-  const profile = getContext<StatsType>("profile");
+  import { getProfileCtx } from "$ctx/profile.svelte";
+  const { profile } = getProfileCtx();
 
   const highestPriorityFishingTool = profile.items.fishing_tools.highest_priority_tool;
   const fishingTools = profile.items.fishing_tools.tools;

--- a/src/lib/sections/stats/skills/mining.svelte
+++ b/src/lib/sections/stats/skills/mining.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getProfileCtx } from "$ctx/profile.svelte";
   import AdditionStat from "$lib/components/AdditionStat.svelte";
   import Item from "$lib/components/Item.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
@@ -9,11 +10,10 @@
   import { format } from "numerable";
   import { fade } from "svelte/transition";
 
-  import { getProfileCtx } from "$ctx/profile.svelte";
   const { profile } = getProfileCtx();
 
-  const highestPriorityMiningTool = profile.items.mining_tools.highest_priority_tool;
-  const miningTools = profile.items.mining_tools.tools;
+  const highestPriorityMiningTool = $derived(profile.items.mining_tools.highest_priority_tool);
+  const miningTools = $derived(profile.items.mining_tools.tools);
 </script>
 
 <Items>

--- a/src/lib/sections/stats/skills/mining.svelte
+++ b/src/lib/sections/stats/skills/mining.svelte
@@ -5,13 +5,12 @@
   import Items from "$lib/layouts/stats/Items.svelte";
   import { getRarityClass } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
-  import type { ValidStats as StatsType } from "$lib/types/stats";
   import { formatDate, formatDistanceStrict } from "date-fns";
   import { format } from "numerable";
-  import { getContext } from "svelte";
   import { fade } from "svelte/transition";
 
-  const profile = getContext<StatsType>("profile");
+  import { getProfileCtx } from "$ctx/profile.svelte";
+  const { profile } = getProfileCtx();
 
   const highestPriorityMiningTool = profile.items.mining_tools.highest_priority_tool;
   const miningTools = profile.items.mining_tools.tools;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,7 +23,8 @@ const config = {
       $params: "./src/params",
       $types: "./src/lib/types",
       $db: "./src/db",
-      $constants: "./src/lib/server/constants"
+      $constants: "./src/lib/server/constants",
+      $ctx: "./src/context"
     },
     csrf: {
       checkOrigin: true


### PR DESCRIPTION
This PR changes the way profile data is passed around by using a custom context wrapper. This change allows for everything to correctly be reactive based off of profile data.

Old (not reactive)
```ts
import { getContext } from 'svelte';
const profile = getContext<StatsType>("profile");
```
New (reactive)
```ts
import { getProfileCtx } from '$ctx/profile.svelte';
const { profile } = getProfileCtx();
// And for easy misc data access
const { misc } = getProfileCtx();
```

