### PR TITLE
Catch NEU-REPO clone error

### DIFF
--- a/src/lib/server/helper/NotEnoughUpdates/parseNEURepository.ts
+++ b/src/lib/server/helper/NotEnoughUpdates/parseNEURepository.ts
@@ -32,9 +32,9 @@ export async function intializeNEURepository() {
     } catch (error) {
       if (error instanceof GitError && error.message.includes("already exists")) {
         console.log("[NOT-ENOUGH-UPDATES] Repository already exists.");
+      } else {
+        console.error("[NOT-ENOUGH-UPDATES] Error cloning repository:", error);
       }
-
-      console.error("[NOT-ENOUGH-UPDATES] Error cloning repository:", error);
     }
   }
 }

--- a/src/lib/server/helper/NotEnoughUpdates/parseNEURepository.ts
+++ b/src/lib/server/helper/NotEnoughUpdates/parseNEURepository.ts
@@ -1,7 +1,7 @@
 import { building, dev } from "$app/environment";
 import type { NEUItem } from "$types/processed/NotEnoughUpdates/NotEnoughUpdates";
 import fs from "node:fs";
-import simpleGit from "simple-git";
+import { GitError, simpleGit } from "simple-git";
 import { NBTParser } from "./NBTParser";
 import { formatBestiaryConstants } from "./parsers/bestiary";
 import { updateNotEnoughUpdatesRepository } from "./updateNEURepository";
@@ -27,7 +27,15 @@ export async function intializeNEURepository() {
 
   if (!dev || !fs.existsSync("NotEnoughUpdates-REPO/.git")) {
     console.log(`[NOT-ENOUGH-UPDATES] Cloning NEU repository.`);
-    await simpleGit().clone("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO", "NotEnoughUpdates-REPO");
+    try {
+      await simpleGit().clone("https://github.com/NotEnoughUpdates/NotEnoughUpdates-REPO", "NotEnoughUpdates-REPO");
+    } catch (error) {
+      if (error instanceof GitError && error.message.includes("already exists")) {
+        console.log("[NOT-ENOUGH-UPDATES] Repository already exists.");
+      }
+
+      console.error("[NOT-ENOUGH-UPDATES] Error cloning repository:", error);
+    }
   }
 }
 


### PR DESCRIPTION
Catches the NEU REPO clone error on production builds. Just doing it like this (should) be fine, as the error indicates that the repo already exists anyway. Most of the logic here should eventually be improved though.