### PR TITLE
Fix URL rewriting causing a second navigation/page load

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -93,10 +93,7 @@
           if (isIntersecting) {
             let newHash;
             newHash = "#" + element.id;
-            replaceState(newHash, {
-              ...page,
-              url: { ...page.url, hash: newHash }
-            });
+            replaceState(newHash, page.state);
             for (const link of navBarLinks) {
               if (link.hash === newHash) {
                 activeSection = link.hash.slice(1);

--- a/src/routes/stats/[ign]/[[profile]]/+page.svelte
+++ b/src/routes/stats/[ign]/[[profile]]/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { replaceState } from "$app/navigation";
   import { page } from "$app/state";
   import { setProfileCtx } from "$ctx/profile.svelte";
   import Main from "$lib/layouts/stats/Main.svelte";
   import type { ValidStats } from "$types/stats";
-  import { untrack } from "svelte";
+  import { tick, untrack } from "svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -28,7 +28,8 @@
       // Update the URL to match the username and cute name
       if (current !== wanted) {
         const newUrl = page.url.toString().replace(current, wanted);
-        goto(newUrl, { replaceState: true });
+        // Tick to wait for the router to initialize
+        tick().then(() => replaceState(newUrl, page.state));
       }
     });
   });


### PR DESCRIPTION
Apparently, `goto(url, { replaceState: true })` doesn't do what we want, and `replaceState(url, page.state)` is correct. 

I also fixed the `page.state` parameter passed into the navbar code that updates the page hash, as we didn't understand what it was for at the time.