### PR TITLE
Make profile param in `/api/stats` optional

### DIFF
--- a/src/routes/api/stats/[paramPlayer=player]/[[paramProfile]]/+server.ts
+++ b/src/routes/api/stats/[paramPlayer=player]/[[paramProfile]]/+server.ts
@@ -6,7 +6,7 @@ import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ params, cookies }) => {
   const timeNow = Date.now();
-  const { paramPlayer, paramProfile } = params;
+  const { paramPlayer, paramProfile = null } = params;
 
   const [profile, player] = await Promise.all([getProfile(paramPlayer, paramProfile, { cache: true }), fetchPlayer(paramPlayer, { cache: true })]);
   const museum = await fetchMuseum(profile.profile_id);
@@ -15,7 +15,7 @@ export const GET: RequestHandler = async ({ params, cookies }) => {
   const stats = await getStats(profile, player, { museum, packs: packs });
 
   if (dev) {
-    console.log(`/api/stats/${paramPlayer}${paramProfile !== "undefined" ? `/${paramProfile}` : ""} took ${Date.now() - timeNow}ms`);
+    console.log(`/api/stats/${paramPlayer}${paramProfile ? `/${paramProfile}` : ""} took ${Date.now() - timeNow}ms`);
   }
 
   return json(stats);

--- a/src/routes/stats/[ign]/[[profile]]/+page.server.ts
+++ b/src/routes/stats/[ign]/[[profile]]/+page.server.ts
@@ -4,7 +4,7 @@ import type { PageServerLoad } from "./$types";
 export const load = (async ({ params, fetch }) => {
   const { ign, profile } = params;
 
-  const data = await fetch(`/api/stats/${ign}/${profile}`)
+  const data = await fetch(`/api/stats/${ign}${profile ? "/" + profile : ""}`)
     .then((res) => res.json() as Promise<StatsType>)
     .catch((err) => {
       console.error(err);


### PR DESCRIPTION
Changes the `/api/stats/` endpoint to make the profile parameter optional instead of passing the string "undefined" to it.