### PR TITLE
Fix profile switching in production

### DIFF
--- a/src/lib/server/stats.ts
+++ b/src/lib/server/stats.ts
@@ -32,10 +32,10 @@ async function processStats<T>(player: Player, profile: Profile, stats: Array<[s
 
 export async function getStats(profile: Profile, player: Player, extra: { museum?: MuseumRawResponse; packs?: string[] } = {}) {
   const timeNow = Date.now();
-  const cacheId = `STATS:${profile.uuid}:${extra.packs?.join(",") ?? "NONE"}`;
+  const cacheId = `STATS:${profile.uuid}:${profile.profile_id}:${extra.packs?.join(",") ?? "NONE"}`;
   const cache = await REDIS.get(cacheId);
   if (cache && !dev) {
-    console.log(`[CACHE] Found cache for ${profile.uuid} in ${Date.now() - timeNow}ms`);
+    console.log(`[CACHE] Found cache for ${profile.uuid}:${profile.profile_id} in ${Date.now() - timeNow}ms`);
     return JSON.parse(cache);
   }
 


### PR DESCRIPTION
The redis cache key only used player uuid before, which meant that it was impossible to switch profiles after loading one of them.