### PR TITLE
Update branding and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pnpm prune --production
 FROM node:22-alpine3.21
 # git is used for managing submodules
 RUN apk add git
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 WORKDIR /app
 
 COPY --from=builder /app/node_modules node_modules/

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "runbuild": "node ./build/index.js",
     "test": "vitest",
     "lint": "prettier --check . && eslint . && pnpm check",
-    "format": "prettier --write .",
-    "prepare": "svelte-kit sync"
+    "format": "prettier --write ."
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",

--- a/src/lib/components/header/Info.svelte
+++ b/src/lib/components/header/Info.svelte
@@ -73,7 +73,7 @@
       </ul>
     </li>
     <li>
-      3D Skin View: <Button.Root class="text-link font-semibold" rel="noreferrer" href="https://github.com/bs-community/skinview3d/" target="_blank">Skin View 3D</Button.Root>
+      3D Skin View: <Button.Root class="text-link font-semibold" rel="noreferrer" href="https://github.com/bs-community/skinview3d/" target="_blank">skinview3d</Button.Root>
       by <span class="text-text/70">BS-Community</span>
     </li>
     <li>


### PR DESCRIPTION
Align the link text for 3D Skin View with branding standards and update the pnpm version to 10 while removing an unused prepare script from package.json.