### PR TITLE
Update Patreon title for clarity in call-to-action

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,7 +44,7 @@
     {
       href: PUBLIC_PATREON,
       text: {
-        title: "SkyCrypt's",
+        title: "Patreon",
         description: "Help keep SkyCrypt ad free by donating"
       },
       img: {


### PR DESCRIPTION
Clarify the Patreon title in the call-to-action to improve user understanding.