### PR TITLE
feat: add Kuudra Follower Hunt info

### DIFF
--- a/src/lib/sections/stats/CrimsonIsle.svelte
+++ b/src/lib/sections/stats/CrimsonIsle.svelte
@@ -51,7 +51,7 @@
 
       <SectionSubtitle class="my-0">Kuudra Follower Hunt</SectionSubtitle>
       <div class="space-y-0.5">
-        <AdditionStat text="Last Believer Blessing" data={formatTimestamp(isle.kuudraFollower.lastBelieverBlessing)} />
+        <AdditionStat text="Last Believer Blessing" data={isle.kuudraFollower.lastBelieverBlessing ? formatTimestamp(isle.kuudraFollower.lastBelieverBlessing) : "Never"} />
         <AdditionStat text="Talked to Weird Sailor" data={isle.kuudraFollower.weirdSailor ? "Yes" : "No"} maxed={isle.kuudraFollower.weirdSailor} />
         <AdditionStat text="Fished Wet Napkin" data={isle.kuudraFollower.fishedWetNapkin ? "Yes" : "No"} maxed={isle.kuudraFollower.fishedWetNapkin} />
         <AdditionStat text="Clicked Bookshelf" data={isle.kuudraFollower.foundKuudraBook ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraBook} />

--- a/src/lib/sections/stats/CrimsonIsle.svelte
+++ b/src/lib/sections/stats/CrimsonIsle.svelte
@@ -48,6 +48,17 @@
           </Chip>
         {/each}
       </ScrollItems>
+
+      <SectionSubtitle class="my-0">Kuudra Follower Hunt</SectionSubtitle>
+      <div class="space-y-0.5">
+        <AdditionStat text="Talked to Weird Sailor" data={isle.kuudraFollower.weirdSailor ? "Yes" : "No"} maxed={isle.kuudraFollower.weirdSailor} />
+        <AdditionStat text="Fished Wet Napkin" data={isle.kuudraFollower.fishedWetNapkin ? "Yes" : "No"} maxed={isle.kuudraFollower.fishedWetNapkin} />
+        <AdditionStat text="Obtained Helmet" data={isle.kuudraFollower.foundKuudraHelmet ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraHelmet} />
+        <AdditionStat text="Obtained Chestplate" data={isle.kuudraFollower.foundKuudraChestplate ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraChestplate} />
+        <AdditionStat text="Obtained Leggings" data={isle.kuudraFollower.foundKuudraLeggings ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraLeggings} />
+        <AdditionStat text="Obtained Boots" data={isle.kuudraFollower.foundKuudraBoots ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraBoots} />
+        <AdditionStat text="Plaque Rarity" data={isle.kuudraFollower.cavityRarity ?? "None"} maxed={isle.kuudraFollower.cavityRarity === "SPECIAL"} />
+      </div>
     {/if}
 
     {#if isle.dojo.totalPoints}

--- a/src/lib/sections/stats/CrimsonIsle.svelte
+++ b/src/lib/sections/stats/CrimsonIsle.svelte
@@ -6,7 +6,7 @@
   import ScrollItems from "$lib/components/scroll-items.svelte";
   import SectionSubtitle from "$lib/components/SectionSubtitle.svelte";
   import Items from "$lib/layouts/stats/Items.svelte";
-  import { formatTime } from "$lib/shared/helper";
+  import { formatTime, formatTimestamp } from "$lib/shared/helper";
   import { cn } from "$lib/shared/utils";
   import { format } from "numerable";
 
@@ -51,8 +51,11 @@
 
       <SectionSubtitle class="my-0">Kuudra Follower Hunt</SectionSubtitle>
       <div class="space-y-0.5">
+        <AdditionStat text="Last Believer Blessing" data={formatTimestamp(isle.kuudraFollower.lastBelieverBlessing)} />
         <AdditionStat text="Talked to Weird Sailor" data={isle.kuudraFollower.weirdSailor ? "Yes" : "No"} maxed={isle.kuudraFollower.weirdSailor} />
         <AdditionStat text="Fished Wet Napkin" data={isle.kuudraFollower.fishedWetNapkin ? "Yes" : "No"} maxed={isle.kuudraFollower.fishedWetNapkin} />
+        <AdditionStat text="Clicked Bookshelf" data={isle.kuudraFollower.foundKuudraBook ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraBook} />
+        <AdditionStat text="Talked to Loremaster" data={isle.kuudraFollower.kuudraLoremaster ? "Yes" : "No"} maxed={isle.kuudraFollower.kuudraLoremaster} />
         <AdditionStat text="Obtained Helmet" data={isle.kuudraFollower.foundKuudraHelmet ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraHelmet} />
         <AdditionStat text="Obtained Chestplate" data={isle.kuudraFollower.foundKuudraChestplate ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraChestplate} />
         <AdditionStat text="Obtained Leggings" data={isle.kuudraFollower.foundKuudraLeggings ? "Yes" : "No"} maxed={isle.kuudraFollower.foundKuudraLeggings} />

--- a/src/lib/server/helper.ts
+++ b/src/lib/server/helper.ts
@@ -1,5 +1,4 @@
 import type { Item, ProcessedItem } from "$types/stats";
-import { format } from "date-fns";
 import { getPrices } from "skyhelper-networth";
 import * as constants from "./constants/constants";
 import { getTexture } from "./custom_resources";
@@ -189,18 +188,6 @@ export function getHeadTextureUUID(value: string) {
   const uuid = url.split("/").pop();
 
   return uuid;
-}
-
-export function formatTimestamp(timestamp: number, formatType: string = "MMM d, yyyy, h:mm a") {
-  if (new Date(Number(timestamp)).toString() == "Invalid Date") {
-    timestamp = new Date(timestamp).getTime();
-  }
-
-  if (new Date(Number(timestamp)).toString() == "Invalid Date") {
-    return "Invalid Date";
-  }
-
-  return format(new Date(Number(timestamp)), formatType);
 }
 
 export function sortByRarity(object: Record<string, unknown>) {

--- a/src/lib/server/stats/crimson_isle.ts
+++ b/src/lib/server/stats/crimson_isle.ts
@@ -83,6 +83,15 @@ export function getCrimsonIsle(userProfile: Member) {
       magesReputation: userProfile.nether_island_player_data?.mages_reputation ?? 0
     },
     kuudra: getKuudra(userProfile),
+    kuudraFollower: {
+      weirdSailor: userProfile.nether_island_player_data?.quests?.weird_sailor ?? false,
+      fishedWetNapkin: userProfile.nether_island_player_data?.quests?.fished_wet_napkin ?? false,
+      foundKuudraHelmet: userProfile.nether_island_player_data?.quests?.found_kuudra_helmet ?? false,
+      foundKuudraChestplate: userProfile.nether_island_player_data?.quests?.found_kuudra_chestplate ?? false,
+      foundKuudraLeggings: userProfile.nether_island_player_data?.quests?.found_kuudra_leggings ?? false,
+      foundKuudraBoots: userProfile.nether_island_player_data?.quests?.found_kuudra_boots ?? false,
+      cavityRarity: userProfile.nether_island_player_data?.quests?.cavity_rarity?.toUpperCase()
+    },
     dojo: getDojo(userProfile)
   };
 }

--- a/src/lib/server/stats/crimson_isle.ts
+++ b/src/lib/server/stats/crimson_isle.ts
@@ -84,8 +84,11 @@ export function getCrimsonIsle(userProfile: Member) {
     },
     kuudra: getKuudra(userProfile),
     kuudraFollower: {
+      lastBelieverBlessing: userProfile.nether_island_player_data?.quests?.last_believer_blessing,
       weirdSailor: userProfile.nether_island_player_data?.quests?.weird_sailor ?? false,
       fishedWetNapkin: userProfile.nether_island_player_data?.quests?.fished_wet_napkin ?? false,
+      foundKuudraBook: userProfile.nether_island_player_data?.quests?.found_kuudra_book ?? false,
+      kuudraLoremaster: userProfile.nether_island_player_data?.quests?.kuudra_loremaster ?? false,
       foundKuudraHelmet: userProfile.nether_island_player_data?.quests?.found_kuudra_helmet ?? false,
       foundKuudraChestplate: userProfile.nether_island_player_data?.quests?.found_kuudra_chestplate ?? false,
       foundKuudraLeggings: userProfile.nether_island_player_data?.quests?.found_kuudra_leggings ?? false,

--- a/src/lib/server/stats/items/museum.ts
+++ b/src/lib/server/stats/items/museum.ts
@@ -1,4 +1,4 @@
-import * as helper from "$lib/server/helper";
+import { formatTimestamp } from "$lib/shared/helper";
 import type { DecodedMuseumItems } from "$types/global";
 import type { MuseumRaw } from "$types/raw/museum/lib";
 import { decodeItems, decodeItemsObject } from "./decoding";
@@ -23,7 +23,7 @@ export async function decodeMusemItems(museum: MuseumRaw, packs: string[]): Prom
           .map((i) => {
             const itemLore = i.tag.display.Lore;
             if (donatedTime) {
-              itemLore.push("", `§7Donated: §c${helper.formatTimestamp(donatedTime)}`);
+              itemLore.push("", `§7Donated: §c${formatTimestamp(donatedTime)}`);
             }
             if (isBorrowing) {
               itemLore.push("", `§7Status: §cBorrowing`);
@@ -51,7 +51,7 @@ export async function decodeMusemItems(museum: MuseumRaw, packs: string[]): Prom
           .map((i) => {
             const itemLore = i.tag.display.Lore;
             if (donatedTime) {
-              itemLore.push("", `§7Donated: §c${helper.formatTimestamp(donatedTime)}`);
+              itemLore.push("", `§7Donated: §c${formatTimestamp(donatedTime)}`);
             }
             return i;
           });

--- a/src/lib/server/stats/items/processing.ts
+++ b/src/lib/server/stats/items/processing.ts
@@ -6,6 +6,7 @@ import type { Item, ProcessedItem } from "$types/stats";
 import { NEU_ITEMS } from "$lib/server/helper/NotEnoughUpdates/parseNEURepository";
 import { getItemNetworth } from "skyhelper-networth";
 import { addLevelableEnchantmentsToLore, parseItemGems } from "./helper";
+import { formatTimestamp } from "$lib/shared/helper";
 
 export function itemSorter(a: ProcessedItem, b: ProcessedItem) {
   if (a.rarity && b.rarity && a.rarity !== b.rarity) {
@@ -123,7 +124,7 @@ export async function processItems(items: ProcessedItem[], source: string, packs
       }
 
       if (item.tag.ExtraAttributes.timestamp) {
-        itemLore.push("", `§7Obtained: §c${helper.formatTimestamp(item.tag.ExtraAttributes.timestamp)}`);
+        itemLore.push("", `§7Obtained: §c${formatTimestamp(item.tag.ExtraAttributes.timestamp)}`);
       }
 
       if (item.tag?.display?.color) {

--- a/src/lib/shared/helper.ts
+++ b/src/lib/shared/helper.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { MAX_ENCHANTS } from "$lib/shared/constants/enchantments";
 import { RARITY_COLORS } from "$lib/shared/constants/items";
 import type { ProcessedItem } from "$types/global";
@@ -20,6 +21,19 @@ export function formatNumber(n: number, digits = 2) {
     .format(n)
     .replace(/\.0+([A-Za-z])?$/, "$1");
 }
+
+export function formatTimestamp(timestamp: number, formatType: string = "MMM d, yyyy, h:mm a") {
+  if (new Date(Number(timestamp)).toString() == "Invalid Date") {
+    timestamp = new Date(timestamp).getTime();
+  }
+
+  if (new Date(Number(timestamp)).toString() == "Invalid Date") {
+    return "Invalid Date";
+  }
+
+  return format(new Date(Number(timestamp)), formatType);
+}
+
 
 /**
  * Converts a string to title case

--- a/src/lib/types/processed/profile/crimson_isle.d.ts
+++ b/src/lib/types/processed/profile/crimson_isle.d.ts
@@ -14,6 +14,15 @@ export type CrimsonIsle = {
       kills: number;
     }[];
   };
+  kuudraFollower: {
+    weirdSailor: boolean;
+    fishedWetNapkin: boolean;
+    foundKuudraHelmet: boolean;
+    foundKuudraChestplate: boolean;
+    foundKuudraLeggings: boolean;
+    foundKuudraBoots: boolean;
+    cavityRarity: string?;
+  };
   dojo: {
     totalPoints: number;
     challenges: {

--- a/src/lib/types/processed/profile/crimson_isle.d.ts
+++ b/src/lib/types/processed/profile/crimson_isle.d.ts
@@ -15,8 +15,11 @@ export type CrimsonIsle = {
     }[];
   };
   kuudraFollower: {
+    lastBelieverBlessing: number?;
     weirdSailor: boolean;
     fishedWetNapkin: boolean;
+    clickedBookshelf: boolean;
+    kuudraLoremaster: boolean;
     foundKuudraHelmet: boolean;
     foundKuudraChestplate: boolean;
     foundKuudraLeggings: boolean;

--- a/src/lib/types/raw/profile/lib.d.ts
+++ b/src/lib/types/raw/profile/lib.d.ts
@@ -204,6 +204,15 @@ export type NetherIslandPlayerData = {
   selected_faction: string;
   mages_reputation: number;
   barbarians_reputation: number;
+  quests?: {
+    weird_sailor?: boolean;
+    fished_wet_napkin?: boolean;
+    found_kuudra_helmet?: boolean;
+    found_kuudra_chestplate?: boolean;
+    found_kuudra_leggings?: boolean;
+    found_kuudra_boots?: boolean;
+    cavity_rarity?: string;
+  };
 };
 
 export type ProfilePets = {

--- a/src/lib/types/raw/profile/lib.d.ts
+++ b/src/lib/types/raw/profile/lib.d.ts
@@ -205,8 +205,11 @@ export type NetherIslandPlayerData = {
   mages_reputation: number;
   barbarians_reputation: number;
   quests?: {
+    last_believer_blessing?: number;
     weird_sailor?: boolean;
     fished_wet_napkin?: boolean;
+    found_kuudra_book?: boolean;
+    kuudra_loremaster?: boolean;
     found_kuudra_helmet?: boolean;
     found_kuudra_chestplate?: boolean;
     found_kuudra_leggings?: boolean;


### PR DESCRIPTION
Primarily inspired by Hypixel being bugged and crediting the Wet Napkin to players without actually giving it to them or showing a chat message (it is something you can only obtain once), but also adds a few other potentially useful pieces of information.