### PR TITLE
Change Twitter card type to summary

### DIFF
--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -36,7 +36,7 @@
     site_name: "SkyCrypt"
   }}
   twitter={{
-    card: "summary_large_image",
+    card: "summary",
     image: `https://visage.surgeplay.com/bust/${embedData.uuid}?y=-40`,
     imageAlt: embedData.displayName,
     title: getMetaTitle(embedData),


### PR DESCRIPTION
Update the Twitter card type from `summary_large_image` to `summary` for improved compatibility.