### PR TITLE
Remove exotic color codes from items

### DIFF
--- a/src/lib/server/db/mongo/update-items.ts
+++ b/src/lib/server/db/mongo/update-items.ts
@@ -59,6 +59,13 @@ export async function updateItems() {
         obj.texture = getSkinHash(skin.value);
       }
 
+      if (item.color) {
+        obj.hex_color = (item.color as string)
+          .split(",")
+          .map((c) => parseInt(c).toString(16).padStart(2, "0"))
+          .join("");
+      }
+
       items[id] = obj;
     }
 

--- a/src/lib/server/stats/items.ts
+++ b/src/lib/server/stats/items.ts
@@ -1,9 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { EXOTIC_ITEMS } from "$constants/items";
 import type { GetItemsItems, Member, MuseumRaw } from "$types/global";
 import { REDIS } from "../db/redis";
-import { getId } from "../helper";
 import { sendWebhookMessage } from "../lib";
 import { decodeItems } from "./items/decoding";
 import { decodeMusemItems } from "./items/museum";
@@ -139,36 +137,6 @@ export async function getItems(userProfile: Member, userMuseum: MuseumRaw | null
 
     // REDIS.set(`items:${profileId}:all`, JSON.stringify(allItems), "EX", 60 * 5); // 5 minutes cache
     // REDIS.set(`items:${profileId}:all:object`, JSON.stringify(output), "EX", 60 * 5);
-
-    // ? NOTE: This is to troll exotic collectors, it will randomly color an item. This was an idea by Vinush (697136515461152768)
-    const SHOULD_RANDOMIZE_COLORS_REQUIREMENTS = !userProfile?.player_data?.visited_zones?.includes("rift") && userProfile.profile?.first_join < new Date("2024-01-01").getTime();
-    const SHOULD_RANDOMIZE_COLORS = Math.random() < 0.01 && SHOULD_RANDOMIZE_COLORS_REQUIREMENTS;
-    const MAX_ITEMS_TO_RANDOMIZE = Math.floor(Math.random() * 10) + 1;
-    if (SHOULD_RANDOMIZE_COLORS) {
-      const eligibleItems = [];
-      for (const inventory of Object.values(output)) {
-        for (const item of inventory) {
-          if (item.tag?.display?.color && EXOTIC_ITEMS.includes(getId(item))) {
-            eligibleItems.push(item);
-          }
-        }
-      }
-
-      const itemsToRandomize = Math.min(MAX_ITEMS_TO_RANDOMIZE, eligibleItems.length);
-
-      const selectedItems = [];
-      for (let i = 0; i < itemsToRandomize; i++) {
-        const randomIndex = Math.floor(Math.random() * eligibleItems.length);
-        selectedItems.push(eligibleItems.splice(randomIndex, 1)[0]);
-      }
-
-      for (const item of selectedItems) {
-        const randomHex = Math.floor(Math.random() * 0xffffff)
-          .toString(16)
-          .padStart(6, "0");
-        item.tag.display.color = parseInt(randomHex, 16);
-      }
-    }
 
     // NOTE: Timestamps are stringified to prevent issues with Redis or JSON serialization, as they may not handle large numbers (e.g., BigInt) correctly.
     for (const inventory of Object.values(output)) {

--- a/src/lib/server/stats/items/processing.ts
+++ b/src/lib/server/stats/items/processing.ts
@@ -89,6 +89,27 @@ export async function processItems(items: ProcessedItem[], source: string, packs
       item.extra = { source };
     }
 
+    // Remove any exotic color codes
+    if (item.tag?.display?.color && item.tag.ExtraAttributes.id) {
+      let color = "";
+
+      // Use default color from constants if not dyed
+      if (!item.tag.ExtraAttributes.dye_item) {
+        const defaultColor = constants.ITEMS.get(item.tag.ExtraAttributes.id)?.hex_color;
+        if (defaultColor) {
+          color = defaultColor;
+        }
+      } else {
+        // Use color if dye_item is set (it's probably just dyed, not exotic)
+        color = (item.tag.display.color as unknown as number).toString(16).padStart(6, "0");
+      }
+
+      if (color) {
+        // For some reason this is typed as a string, but it should be a number
+        item.tag.display.color = parseInt(color, 16) as unknown as string;
+      }
+    }
+
     if (!options?.pack) {
       helper.applyResourcePack(item, packs);
     }

--- a/src/lib/types/processed/profile/items.d.ts
+++ b/src/lib/types/processed/profile/items.d.ts
@@ -39,6 +39,7 @@ export type DatabaseItem = {
   item_id?: number;
   skyblock_id?: string;
   color?: string;
+  hex_color?: string;
   damage?: number;
   museum_data?: {
     armor_set_donation_xp: number;
@@ -96,6 +97,7 @@ export type ProcessedItem = {
       };
       talisman_enrichment?: string;
       gems: Record<string, string>;
+      dye_item?: string;
     };
     SkullOwner: {
       Properties: {


### PR DESCRIPTION
Exotic collectors have zero respect for SkyCrypts infrastructure and are scraping it constantly looking for exotic color codes. My solution is simple, remove any unique color codes from armor.

There's no reason to scrape anymore.

If an item is dyed the color code is not overridden, I figured the chance of a dyed armor not having the dye color is very unlikely (maybe not even possible). Otherwise, the item color that comes from the Hypixel items endpoint is used.

To be clear, this PR is just a result of bad actors abusing the website. They ruined it for everyone, otherwise there'd be no issue with displaying exotics.