### PR TITLE
Use item shine logic and optimize search query refetching

### DIFF
--- a/src/lib/components/Item.svelte
+++ b/src/lib/components/Item.svelte
@@ -2,7 +2,7 @@
   import ItemContent from "$lib/components/item/item-content.svelte";
   import type { IsHover } from "$lib/hooks/is-hover.svelte";
   import { RARITIES, RARITY_COLORS } from "$lib/shared/constants/items";
-  import { getRarityClass } from "$lib/shared/helper";
+  import { getRarityClass, shouldShine } from "$lib/shared/helper";
   import { cn, flyAndScale } from "$lib/shared/utils";
   import { itemContent, itemContentSpecial, showItem } from "$lib/stores/internal";
   import { performanceMode } from "$lib/stores/preferences";
@@ -31,7 +31,7 @@
   const bgColor = $derived(getRarityClass(piece.rarity ?? ("common".toLowerCase() as string), "bg"));
   const recombobulated = $derived(showRecombobulated && (skyblockItem.recombobulated ?? false));
   const enchanted = $derived(skyblockItem?.texture_path?.includes("/api/leather/") ? false : skyblockItem.shiny);
-  const shine = $derived(!$performanceMode && (enchanted || skyblockItem.shiny));
+  const shine = $derived(!$performanceMode && shouldShine(skyblockItem));
   const showNumbers = $derived(showCount && (skyblockItem.Count ?? 0) > 1);
 
   const isHover = getContext<IsHover>("isHover");

--- a/src/lib/sections/stats/Inventory.svelte
+++ b/src/lib/sections/stats/Inventory.svelte
@@ -4,7 +4,7 @@
   import Notice from "$lib/components/Notice.svelte";
   import Section from "$lib/components/Section.svelte";
   import { api } from "$lib/shared/api";
-  import { renderLore } from "$lib/shared/helper";
+  import { renderLore, shouldShine } from "$lib/shared/helper";
   import { itemContentSpecial } from "$lib/stores/internal";
   import { performanceMode } from "$lib/stores/preferences";
   import type { ProcessedSkyBlockItem } from "$types/stats";
@@ -260,12 +260,6 @@
     easing: cubicOut
   });
 
-  function shouldShine(item: ProcessedSkyBlockItem): boolean | undefined {
-    const enchanted = item.texture_path.includes("/api/leather/") ? false : item.shiny;
-    const shine = !$performanceMode && (enchanted || item.shiny);
-    return shine;
-  }
-
   itemContentSpecial.subscribe((item) => {
     if (item) {
       if (openTab === "search" || openTab === "backpack" || openTab === "museum") {
@@ -451,7 +445,7 @@
     <div class="grid grid-cols-[repeat(9,minmax(1.875rem,4.875rem))] place-content-center gap-1 pt-5 @md:gap-1.5 @xl:gap-2">
       {#each searchedItems as item, index (index)}
         {#if item}
-          <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={shouldShine(item)}>
+          <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={!$performanceMode && shouldShine(item)}>
             {@render itemSnippet(item)}
           </div>
         {:else}
@@ -471,7 +465,7 @@
             {#snippet child({ props })}
               <div {...props}>
                 {#if item.texture_path}
-                  <div class="group-data-[state=active]:bg-text/10 group-data-[state=inactive]:bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={shouldShine(item)}>
+                  <div class="group-data-[state=active]:bg-text/10 group-data-[state=inactive]:bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={!$performanceMode && shouldShine(item)}>
                     {@render itemSnippet(item)}
                   </div>
                 {:else}
@@ -496,7 +490,7 @@
                 {/if}
                 <Tabs.Content value={index.toString()}>
                   {#if containedItem.texture_path}
-                    <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={shouldShine(item)}>
+                    <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={!$performanceMode && shouldShine(item)}>
                       {@render itemSnippet(containedItem)}
                     </div>
                   {:else}
@@ -531,7 +525,7 @@
           {/if}
         {/if}
         {#if item.texture_path}
-          <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={shouldShine(item)}>
+          <div class="bg-text/[0.04] data-[shine=true]:shine relative flex aspect-square items-center justify-center rounded-sm" data-shine={!$performanceMode && shouldShine(item)}>
             {#if tab.id === "inventory"}
               {@render itemSnippet({ ...item, rarity: item.rarity ?? "uncommon" } as ProcessedSkyBlockItem)}
             {:else}

--- a/src/lib/sections/stats/Inventory.svelte
+++ b/src/lib/sections/stats/Inventory.svelte
@@ -14,6 +14,7 @@
   import { createQuery } from "@tanstack/svelte-query";
   import { Avatar, ScrollArea, Tabs } from "bits-ui";
   import { Debounced } from "runed";
+  import { untrack } from "svelte";
   import { cubicOut } from "svelte/easing";
   import { crossfade, fade } from "svelte/transition";
 
@@ -344,8 +345,12 @@
   });
 
   $effect(() => {
-    if (debouncedSearchValue.current && debouncedSearchValue.current !== "" && openTab === "search" && !debouncedSearchValue.pending) {
-      $searchQuery.refetch();
+    if (debouncedSearchValue.current && debouncedSearchValue.current !== "" && openTab === "search") {
+      untrack(() => {
+        if (!debouncedSearchValue.pending) {
+          $searchQuery.refetch();
+        }
+      });
     }
   });
 </script>

--- a/src/lib/shared/helper.ts
+++ b/src/lib/shared/helper.ts
@@ -1,6 +1,6 @@
 import { MAX_ENCHANTS } from "$lib/shared/constants/enchantments";
 import { RARITY_COLORS } from "$lib/shared/constants/items";
-import type { ProcessedItem } from "$types/global";
+import type { ProcessedItem, ProcessedSkyBlockItem } from "$types/global";
 import { tz } from "@date-fns/tz";
 import { format } from "date-fns";
 import prettyMilliseconds from "pretty-ms";
@@ -262,4 +262,9 @@ export function calculatePercentage(value: number, total: number, decimal: numbe
   return Math.floor((value / total) * 100)
     .toFixed(decimal)
     .replace(/\.0+$/, "");
+}
+
+export function shouldShine(item: ProcessedSkyBlockItem): boolean | undefined {
+  const enchanted = item.texture_path.includes("/api/leather/") ? false : item.shiny;
+  return enchanted || item.shiny;
 }


### PR DESCRIPTION
Use the `shouldShine` function to manage shine logic for items and optimize search query refetching by using `untrack` to prevent unnecessary updates that could lead to an infinite fetch loop.