### PR TITLE
fix: Runecrafting level cap after rank removal

### DIFF
--- a/src/lib/server/stats/leveling/leveling.ts
+++ b/src/lib/server/stats/leveling/leveling.ts
@@ -135,7 +135,7 @@ export function getSkillLevelCaps(userProfile: Member, player: Player | null) {
   return {
     farming: 50 + (userProfile.jacobs_contest?.perks?.farming_level_cap || 0),
     taming: 50 + (userProfile.pets_data?.pet_care?.pet_types_sacrificed?.length || 0),
-    runecrafting: player?.newPackageRank ? 25 : 3
+    runecrafting: (player?.newPackageRank ?? "NONE") !== "NONE" ? 25 : 3
   };
 }
 


### PR DESCRIPTION
`newPackageRank` is `null` if the player never had a rank, but `"NONE"` if they had a rank before and it got removed. This PR fixes Runecrafting skill being incorrectly capped at 25 rather than 3 for the latter.