### PR TITLE
Fix runecrafting level cap and improve error handling for expired tokens

### DIFF
--- a/src/lib/components/Notice.svelte
+++ b/src/lib/components/Notice.svelte
@@ -39,9 +39,17 @@
 
   {#if type === "error"}
     {#if error && error.message}
-      <p class="text-center">
-        {error.message}
-      </p>
+      {#if error.message === "Authentication token has expired"}
+        <p class="text-center">Your authentication token has expired. Please <Button.Root onpointerdown={() => window.location.reload()} class="underline">refresh the page</Button.Root> to generate a new one</p>
+        <p class="text-center">
+          If that doesn't work, please go to <Button.Root href="https://time.is" class="underline">time.is</Button.Root>
+          and check if your time is exact and set your time correctly if it isn't.
+        </p>
+      {:else}
+        <p class="text-center">
+          {error.message}
+        </p>
+      {/if}
     {/if}
 
     <p class="text-center">If applicable, please report this error on our <Button.Root target="_blank" href={PUBLIC_DISCORD_INVITE} class="underline">Discord</Button.Root></p>

--- a/src/lib/server/stats/leveling/leveling.ts
+++ b/src/lib/server/stats/leveling/leveling.ts
@@ -135,7 +135,7 @@ export function getSkillLevelCaps(userProfile: Member, player: Player | null) {
   return {
     farming: 50 + (userProfile.jacobs_contest?.perks?.farming_level_cap || 0),
     taming: 50 + (userProfile.pets_data?.pet_care?.pet_types_sacrificed?.length || 0),
-    runecrafting: player?.newPackageRank ? 25 : 3
+    runecrafting: (player?.newPackageRank ?? "NONE") !== "NONE" ? 25 : 3
   };
 }
 


### PR DESCRIPTION
Remove the runecrafting level cap based on rank and enhance the error message for expired authentication tokens in the Notice component.