### PR TITLE
Ensure frame-ancestors is an array of strings

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -47,7 +47,7 @@ const config = {
         "img-src": ["self", "data:", "https://vzge.me", "https://crafatar.com", "https://mc-heads.net"],
         "connect-src": ["self", "https://crafatar.com"],
         "font-src": ["self", "https://fonts.gstatic.com"],
-        "frame-ancestors": "*"
+        "frame-ancestors": ["*"]
       }
     }
   },


### PR DESCRIPTION
Update the `frame-ancestors` directive in the configuration to be an array of strings for consistency and correctness.