### PR TITLE
Enhance accessibility and update CSP configuration

### DIFF
--- a/src/lib/layouts/stats/Main.svelte
+++ b/src/lib/layouts/stats/Main.svelte
@@ -109,10 +109,11 @@
 <svelte:window bind:innerWidth />
 
 <div class="@container/parent relative">
-  <PaneGroup direction="horizontal" autoSaveId="paneConfig" class="relative w-full !overflow-x-clip !overflow-y-visible">
+  <PaneGroup id="panes" direction="horizontal" autoSaveId="paneConfig" class="relative w-full !overflow-x-clip !overflow-y-visible">
     {#if innerWidth >= 1024}
       <div class="group/pane contents">
         <Pane
+          id="skinPane"
           defaultSize={defaultLeftPanel}
           collapsedSize={0}
           collapsible={true}
@@ -163,6 +164,7 @@
     {/if}
 
     <Pane
+      id="statsPane"
       defaultSize={defaultRightPanel}
       class="relative z-10 !overflow-x-clip !overflow-y-visible"
       order={1}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -46,8 +46,7 @@ const config = {
         "style-src": ["self", "unsafe-inline", "https://fonts.googleapis.com"],
         "img-src": ["self", "data:", "https://vzge.me", "https://crafatar.com", "https://mc-heads.net"],
         "connect-src": ["self", "https://crafatar.com"],
-        "font-src": ["self", "https://fonts.gstatic.com"],
-        "frame-ancestors": ["*"]
+        "font-src": ["self", "https://fonts.gstatic.com"]
       }
     }
   },


### PR DESCRIPTION
Add IDs to PaneGroup and Pane components to improve accessibility. Remove the frame-ancestors directive from the CSP configuration to allow embedding.