### PR TITLE
fix: crystal nucleus run count pluralization

### DIFF
--- a/src/lib/sections/stats/skills/mining.svelte
+++ b/src/lib/sections/stats/skills/mining.svelte
@@ -71,7 +71,7 @@
         </span>
       </h3>
     </AdditionStat>
-    <AdditionStat text="Crystal Nucleus" data={`Completed ${mining.crystalHollows.nucleusRuns} ${mining.crystalHollows.nucleusRuns > 1 ? "times" : "time"}`} asterisk={true}>
+    <AdditionStat text="Crystal Nucleus" data={`Completed ${mining.crystalHollows.nucleusRuns} ${mining.crystalHollows.nucleusRuns !== 1 ? "times" : "time"}`} asterisk={true}>
       {@const placableCrystals = ["jade", "amber", "amethyst", "sapphire", "topaz"]}
       <h3 class="text-text/85 text-sm font-bold">Crystals:</h3>
       <ul class="mt-0.5 space-y-0.5 text-sm font-bold">


### PR DESCRIPTION
Hello! Just noticed this small grammar mistake so I fixed it :3
<img width="1440" height="766" alt="Screenshot 2025-10-17 at 23 24 26" src="https://github.com/user-attachments/assets/d43e1169-7147-4883-8975-14e7fe27cdc9" />
