### PR TITLE
Handle non-GET requests and fallback version name

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -46,11 +46,11 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
-  // ignore POST requests etc
-  if (event.request.method !== "GET") return;
+  const url = new URL(event.request.url);
+  // ignore POST requests, chrome-extension requests, etc
+  if (event.request.method !== "GET" || url.protocol === "chrome-extension:") return;
 
   async function respond() {
-    const url = new URL(event.request.url);
     const cache = await caches.open(CACHE);
 
     // `build`/`files` can always be served from the cache

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -53,7 +53,7 @@ const config = {
       }
     },
     version: {
-      name: process.env.PUBLIC_COMMIT_HASH,
+      name: process.env.PUBLIC_COMMIT_HASH || Date.now().toString(),
       pollInterval:
         // in ms
         1000 * 60 // 1 minute


### PR DESCRIPTION
Improve fetch event handling by allowing non-GET requests and chrome-extension URLs. Ensure the version name defaults to the current timestamp if the PUBLIC_COMMIT_HASH is not set.