### PR TITLE
fix(ui): replace deprecated crafatar api with kalifondation

### DIFF
--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <svelte:head>
-  <link rel="icon" href={isStatsPage ? `https://crafatar.com/avatars/${embedData.uuid}?size=32&overlay` : `https://vzge.me/bust/${embedData.uuid}?y=-40`} sizes="32x32" type="image/png" />
+  <link rel="icon" href={isStatsPage ? `https://avatar.kalifondation.fr/avatars/${embedData.uuid}?size=32&overlay` : `https://vzge.me/bust/${embedData.uuid}?y=-40`} sizes="32x32" type="image/png" />
 </svelte:head>
 
 <SvelteSeo

--- a/src/lib/components/Skin3D.svelte
+++ b/src/lib/components/Skin3D.svelte
@@ -27,7 +27,7 @@
     if (loadedUuid === uuid) return;
     canvasIsLoading = true;
 
-    const cape = await ky.head(`https://crafatar.com/capes/${uuid}`).catch(() => ({ ok: false }));
+    const cape = await ky.head(`https://avatar.kalifondation.fr/capes/${uuid}`).catch(() => ({ ok: false }));
 
     if (!viewer) {
       viewer = new skinview3d.SkinViewer({
@@ -39,9 +39,9 @@
       });
     }
 
-    await viewer.loadSkin(`https://crafatar.com/skins/${uuid}`);
+    await viewer.loadSkin(`https://avatar.kalifondation.fr/skins/${uuid}`);
     if (cape.ok) {
-      await viewer.loadCape(`https://crafatar.com/capes/${uuid}`);
+      await viewer.loadCape(`https://avatar.kalifondation.fr/capes/${uuid}`);
     } else {
       viewer.resetCape();
     }

--- a/src/lib/layouts/stats/Main.svelte
+++ b/src/lib/layouts/stats/Main.svelte
@@ -108,7 +108,7 @@
 
 <svelte:head>
   <link rel="canonical" href={`https://sky.shiiyu.moe/stats/${profile.uuid}/${profile.profile_id}`} />
-  <link rel="icon" href="https://crafatar.com/avatars/{profile.uuid}?size=32&overlay" sizes="32x32" type="image/png" />
+  <link rel="icon" href="https://avatar.kalifondation.fr/avatars/{profile.uuid}?size=32&overlay" sizes="32x32" type="image/png" />
   <title>{profile.displayName} | SkyCrypt</title>
 </svelte:head>
 

--- a/src/lib/layouts/stats/PlayerProfile.svelte
+++ b/src/lib/layouts/stats/PlayerProfile.svelte
@@ -93,7 +93,7 @@
                     <div class="flex w-full items-center justify-between gap-2 rounded-lg bg-text/10 p-2 outline-icon transition-colors duration-300 ease-out group-hover:bg-text/20 group-focus-visible:outline-1 group-data-[removed=true]:bg-text/5 group-hover:group-data-[removed=true]:bg-text/20">
                       <div class="flex items-center gap-2 pr-4">
                         <Avatar.Root class="size-8 shrink-0 rounded-sm bg-text/10">
-                          <Avatar.Image loading="lazy" src="https://crafatar.com/avatars/{member.uuid}?size=64&overlay" alt={member.username} class="aspect-square size-8 rounded-sm [image-rendering:pixelated] group-data-[removed=true]:grayscale-100" />
+                          <Avatar.Image loading="lazy" src="https://avatar.kalifondation.fr/avatars/{member.uuid}?size=64&overlay" alt={member.username} class="aspect-square size-8 rounded-sm [image-rendering:pixelated] group-data-[removed=true]:grayscale-100" />
                           <Avatar.Fallback class="flex h-full items-center justify-center text-lg font-semibold text-text/60 uppercase">
                             <img loading="lazy" src="https://mc-heads.net/avatar/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40/64" alt="Steve" class="aspect-square size-8 rounded-sm [image-rendering:pixelated] group-data-[removed=true]:grayscale-100" />
                           </Avatar.Fallback>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -315,7 +315,7 @@
                 {#if !ign || recentSearch.ign !== ign}
                   <Command.LinkItem value={recentSearch.ign} href="/stats/{recentSearch.ign}" class={cn("flex h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2.5 text-sm outline-hidden select-none", $performanceMode ? "data-selected:bg-background-lore" : "data-selected:bg-background-grey")} keywords={[recentSearch.ign, "profile", "player", "favorite", "favorites"]}>
                     <Avatar.Root class="size-4 shrink-0 bg-text/10">
-                      <Avatar.Image loading="lazy" src={recentSearch.uuid ? `https://crafatar.com/avatars/${recentSearch.uuid}?size=64&overlay` : "https://mc-heads.net/avatar/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40/64"} alt={recentSearch.ign} class="aspect-square size-4 [image-rendering:pixelated]" />
+                      <Avatar.Image loading="lazy" src={recentSearch.uuid ? `https://avatar.kalifondation.fr/avatars/${recentSearch.uuid}?size=64&overlay` : "https://mc-heads.net/avatar/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40/64"} alt={recentSearch.ign} class="aspect-square size-4 [image-rendering:pixelated]" />
                       <Avatar.Fallback class="flex h-full items-center justify-center text-lg font-semibold text-text/60 uppercase">
                         {recentSearch.ign.slice(0, 2)}
                       </Avatar.Fallback>
@@ -336,7 +336,7 @@
                 {#if !ign || favorite.ign !== ign}
                   <Command.LinkItem value={favorite.ign} href="/stats/{favorite.ign}" class={cn("flex h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2.5 text-sm outline-hidden select-none", $performanceMode ? "data-selected:bg-background-lore" : "data-selected:bg-background-grey")} keywords={[favorite.ign, favorite.uuid, "profile", "player", "favorite", "favorites"]}>
                     <Avatar.Root class="size-4 shrink-0 bg-text/10">
-                      <Avatar.Image loading="lazy" src={`https://crafatar.com/avatars/${favorite.uuid}?size=64&overlay`} alt={favorite.ign} class="aspect-square size-4 [image-rendering:pixelated]" />
+                      <Avatar.Image loading="lazy" src={`https://avatar.kalifondation.fr/avatars/${favorite.uuid}?size=64&overlay`} alt={favorite.ign} class="aspect-square size-4 [image-rendering:pixelated]" />
                       <Avatar.Fallback class="flex h-full items-center justify-center text-lg font-semibold text-text/60 uppercase">
                         {favorite.ign.slice(0, 2)}
                       </Avatar.Fallback>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -158,7 +158,7 @@
   <div class={cn("relative rounded-lg", { "transition-all duration-300 ease-out hover:scale-105": !options?.tip })}>
     <Button.Root href={options?.tip ? "#" : `/stats/${user.id}`} class={cn("relative flex h-full min-w-0 items-center gap-4 rounded-lg p-5", $performanceMode ? "bg-background-grey" : "backdrop-blur-lg backdrop-brightness-150 backdrop-contrast-60 dark:backdrop-brightness-50 dark:backdrop-contrast-100")}>
       <Avatar.Root class="size-16 shrink-0 rounded-lg bg-text/10">
-        <Avatar.Image loading="lazy" src={options?.tip ? "https://mc-heads.net/avatar/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40/64" : `https://crafatar.com/avatars/${user.id}?size=64&overlay`} alt={user.name} class="aspect-square size-16 rounded-lg [image-rendering:pixelated]" />
+        <Avatar.Image loading="lazy" src={options?.tip ? "https://mc-heads.net/avatar/bc8ea1f51f253ff5142ca11ae45193a4ad8c3ab5e9c6eec8ba7a4fcb7bac40/64" : `https://avatar.kalifondation.fr/avatars/${user.id}?size=64&overlay`} alt={user.name} class="aspect-square size-16 rounded-lg [image-rendering:pixelated]" />
         <Avatar.Fallback class="flex h-full items-center justify-center text-lg font-semibold text-text/60 uppercase">
           {user.name.slice(0, 2)}
         </Avatar.Fallback>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -55,8 +55,8 @@ const config = {
       directives: {
         "script-src": ["self", "unsafe-inline"],
         "style-src": ["self", "unsafe-inline", "https://fonts.googleapis.com"],
-        "img-src": ["self", "data:", "https://vzge.me", "https://crafatar.com", "https://mc-heads.net", "http://localhost:8080", "https://cupcake.shiiyu.moe", "https://sky.shiiyu.moe"],
-        "connect-src": ["self", "https://crafatar.com", "http://localhost:8080", "https://cupcake.shiiyu.moe", "https://sky.shiiyu.moe"],
+        "img-src": ["self", "data:", "https://vzge.me", "https://avatar.kalifondation.fr", "https://mc-heads.net", "http://localhost:8080", "https://cupcake.shiiyu.moe", "https://sky.shiiyu.moe"],
+        "connect-src": ["self", "https://avatar.kalifondation.fr", "http://localhost:8080", "https://cupcake.shiiyu.moe", "https://sky.shiiyu.moe"],
         "font-src": ["self", "https://fonts.gstatic.com"]
       }
     },


### PR DESCRIPTION
This PR replaces the deprecated Crafatar API with the Kalifondation API for fetching player avatars.

- Updated all UI components that relied on Crafatar.
- Updated the URL and adjusted the Content Security Policy (CSP) accordingly.
- Tested locally with the dev environment.
- Verified that avatars display correctly with the new API.
- No breaking changes to existing functionality.
- Build passes without errors only Sentry warnings (not relevant for this change).