### PR TITLE
feat: add bg colour to navbar (bg-background-grey opactity 60)

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -125,7 +125,7 @@
 
 <ScrollAreaPrimitive type="always" class="navbar group sticky! top-[calc(3rem+env(safe-area-inset-top,0))] z-20 overflow-clip" data-pinned={pinned} bind:ref={navbarElement} orientation="horizontal">
   {#snippet viewportChildren()}
-    <div class="flex! flex-nowrap items-center gap-2 pb-2 font-semibold whitespace-nowrap text-text/80">
+    <div class="flex! flex-nowrap items-center gap-2 bg-background-grey/60 pb-2 font-semibold whitespace-nowrap text-text/80">
       <div class="absolute bottom-1.75 z-1 h-0.5 w-[calc(100%+0.5rem)] bg-icon"></div>
       <div class="absolute inset-0 bottom-2 group-data-[pinned=true]:group-data-[mode=dark]/html:bg-[oklch(19.13%_0_0)]/90 group-data-[pinned=true]:group-data-[mode=light]/html:bg-[oklch(95.51%_0_0)]/92"></div>
       {#each filteredSectionOrderPreferences as section, index (index)}

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -125,7 +125,7 @@
 
 <ScrollAreaPrimitive type="always" class="navbar group sticky! top-[calc(3rem+env(safe-area-inset-top,0))] z-20 overflow-clip" data-pinned={pinned} bind:ref={navbarElement} orientation="horizontal">
   {#snippet viewportChildren()}
-    <div class="flex! flex-nowrap items-center gap-2 bg-background-grey/60 pb-2 font-semibold whitespace-nowrap text-text/80">
+    <div class="flex! flex-nowrap items-center gap-2 bg-header pb-2 font-semibold whitespace-nowrap text-text/80">
       <div class="absolute bottom-1.75 z-1 h-0.5 w-[calc(100%+0.5rem)] bg-icon"></div>
       <div class="absolute inset-0 bottom-2 group-data-[pinned=true]:group-data-[mode=dark]/html:bg-[oklch(19.13%_0_0)]/90 group-data-[pinned=true]:group-data-[mode=light]/html:bg-[oklch(95.51%_0_0)]/92"></div>
       {#each filteredSectionOrderPreferences as section, index (index)}

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -4,8 +4,9 @@
   import { getProfileContext } from "$ctx";
   import ScrollAreaPrimitive from "$lib/components/ScrollAreaPrimitive.svelte";
   import type { SectionName } from "$lib/sections/types";
+  import { cn } from "$lib/shared/utils";
   import { tabValue } from "$lib/stores/internal";
-  import { sectionOrderPreferences } from "$lib/stores/preferences";
+  import { performanceMode, sectionOrderPreferences } from "$lib/stores/preferences";
   import ChevronLeft from "@lucide/svelte/icons/chevron-left";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import { Button, ScrollArea } from "bits-ui";
@@ -125,7 +126,7 @@
 
 <ScrollAreaPrimitive type="always" class="navbar group sticky! top-[calc(3rem+env(safe-area-inset-top,0))] z-20 overflow-clip" data-pinned={pinned} bind:ref={navbarElement} orientation="horizontal">
   {#snippet viewportChildren()}
-    <div class="flex! flex-nowrap items-center gap-2 bg-header pb-2 font-semibold whitespace-nowrap text-text/80">
+    <div class={cn("flex! flex-nowrap items-center gap-2 pb-2 font-semibold whitespace-nowrap text-text/80", $performanceMode ? "group-[data-pinned=true]:bg-header" : "group-[data-pinned=true][mode=dark]:backdrop-brightness-30 group-[data-pinned=true][mode=light]:backdrop-brightness-150")}>
       <div class="absolute bottom-1.75 z-1 h-0.5 w-[calc(100%+0.5rem)] bg-icon"></div>
       <div class="absolute inset-0 bottom-2 group-data-[pinned=true]:group-data-[mode=dark]/html:bg-[oklch(19.13%_0_0)]/90 group-data-[pinned=true]:group-data-[mode=light]/html:bg-[oklch(95.51%_0_0)]/92"></div>
       {#each filteredSectionOrderPreferences as section, index (index)}


### PR DESCRIPTION
I could not for the life of me figure out how to setup the backend or make it point to public dev setup, so I tested this myself.

The navbar is currently kinda unreadable when there's something behind because no background colour. I changed using `bg-background-grey/60` tailwind class. Since I could not get the backend to run locally I calculated it manually to get #1f1f1f99 and then tested it using inspect element, I think its actually readable now 

with the bg:
<img width="1504" height="146" alt="image" src="https://github.com/user-attachments/assets/30b86c2a-b063-4346-9cb6-dd4c09088300" />

<img width="797" height="68" alt="image" src="https://github.com/user-attachments/assets/2504705a-971d-4abb-8adf-ace65a9f1503" />


without:

<img width="885" height="76" alt="image" src="https://github.com/user-attachments/assets/444a6743-6eaf-4829-a7ac-8e85b63ed4b4" />

<img width="695" height="98" alt="image" src="https://github.com/user-attachments/assets/865d9b24-6214-4cde-bc21-0c28d083078b" />
