### PR TITLE
feat: shift the popup slightly so it now properly is 8x8 from corner

### DIFF
--- a/src/lib/components/header/Info.svelte
+++ b/src/lib/components/header/Info.svelte
@@ -110,7 +110,7 @@
       <span class="hidden @md:inline">About</span>
     </Popover.Trigger>
     <Popover.Portal>
-      <Popover.Content forceMount side="bottom" sideOffset={8} align="center" collisionPadding={8} class="z-50 max-h-96 max-w-lg overflow-x-clip overflow-y-auto rounded-lg bg-background-grey/95 px-8 py-4">
+      <Popover.Content forceMount side="bottom" sideOffset={20} align="center" collisionPadding={8} class="z-50 max-h-96 max-w-lg overflow-x-clip overflow-y-auto rounded-lg bg-background-grey/95 px-8 py-4">
         {#snippet child({ wrapperProps, props, open })}
           {#if open}
             <div {...wrapperProps}>


### PR DESCRIPTION
<img width="636" height="676" alt="image" src="https://github.com/user-attachments/assets/46908e72-dbba-47e9-ac3b-0c239c0d8aff" />


<img width="828" height="705" alt="image" src="https://github.com/user-attachments/assets/cb3b392c-cb9c-4101-9dbd-6e066d51b8b3" />
