### PR TITLE
Fix GitHub token usage in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,8 @@ jobs:
         id: stable_prep
         run: node scripts/release-stable.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 
       - name: Create Stable GitHub Release
         if: steps.stable_prep.outputs.release_ready == 'true'
@@ -104,4 +105,5 @@ jobs:
           git push origin "$TAG"
           gh release create "$TAG" --title "$TAG" --generate-notes --latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,10 @@ Release behavior details:
 
 - Changesets are authored in feature PRs and merged into `dev`.
 - The release workflow commits version/changelog updates directly on the release branch (`dev` or `prod`) using `github-actions[bot]`.
-- Stable release changes from `prod` are automatically synced back to `dev` by the release workflow to keep branches aligned.
+- Stable release versioning is proposed via `changeset-release/prod` and merged into `prod` through a PR.
 - Do **not** manually maintain `changeset-release/*` branches.
-- Do **not** manually merge `prod` into `dev` for version sync; the workflow handles this.
+- Avoid routine manual `prod` → `dev` sync merges unless you are intentionally bringing over a stable-only hotfix.
+- The stable release workflow uses `PAT_TOKEN` for GitHub CLI release PR/release operations (required when repository setting **"Allow GitHub Actions to create and approve pull requests"** is disabled).
 
 The version bump is determined automatically by changesets:
 


### PR DESCRIPTION
Update the release workflow to use `PAT_TOKEN` instead of `GITHUB_TOKEN` for GitHub CLI operations. Revise contributing guidelines to reflect this change and clarify the release process.

